### PR TITLE
feat: Add hck alternative for cut

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,6 +34,8 @@ A curation of projects worked on by Teknql members as well as recommended tech
   highlighting, git status, line numbers
 - [`ripgrep`](https://github.com/BurntSushi/ripgrep) - `grep` replacement
   :man-running:
+- [`hck`](https://github.com/sstadick/hck) - almost a drop-in replacement for
+  `cut`, with more features
 - [`procs`](https://github.com/dalance/procs) - `ps` replacement
 - [`xh`](https://github.com/ducaale/xh) - `httpie` replacement
 - [`emacs`](https://github.com/emacs-mirror/emacs) - `vim` / `vscode`


### PR DESCRIPTION
I wondered if it existed because I wanted something that could give me the last
several parts of a file path to build a name without having to use `rev`. In my
specific case I wanted to create a json file in the root of my terraform repo
for each module directory that has a main.tf file. I can get the list of json
files like so:

```
$ fd -a -d3 main.tf -x echo {//}.json \; | rev | cut -d/ -f-3 | rev | tr '/' '_'
```

Sadly `hck` doesn't have a way to select the rightmost fields :shrug:

OTOH it does do some other nice stuff, like changing the output delimeters,
allowing me to be a little more concise:

```
$ fd -a -d3 main.tf -x echo {//}.json \; | rev | hck -d/ -D_ -f-3 | rev
```

I'm also creating an issue requesting rightmost field selections, we'll see...
